### PR TITLE
Fix crash error

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -139,6 +139,13 @@ def stream_sorting_filter(expr, stream_weight):
     return func
 
 
+def parse_url_params(url):
+    split = url.split(" ", 1)
+    url = split[0]
+    params = split[1] if len(split) > 1 else ''
+    return url, parse_params(params)
+
+
 def parse_params(params=None):
     # type: (Optional[str]) -> Dict[str, Any]
     rval = {}


### PR DESCRIPTION
Failed to load plugin muxedstream:
  File "/usr/lib/python2.7/site-packages/streamlink/plugins/muxedstream.py", line 6, in <module>
    from streamlink.plugin.plugin import parse_url_params
ImportError: cannot import name parse_url_params